### PR TITLE
Adiciona suporte a css e js do widget

### DIFF
--- a/back-end/actions.php
+++ b/back-end/actions.php
@@ -181,8 +181,12 @@ Class AcfAction {
 
 		foreach($dir as $fileinfo):
 			if($fileinfo->isDir() && !$fileinfo->isDot()):
-				$fields=array();
 				$file = "{$path}/{$fileinfo->getFilename()}/functions.php";
+				
+				if(!file_exists($file))
+					continue;
+
+				$fields=array();
 				$widget = WidgetsWidgets::parseWidgetHeaders($file);
 
 				require($file);

--- a/front-end/functions.php
+++ b/front-end/functions.php
@@ -23,18 +23,22 @@ Class TemplatesWidgets {
 			$html .= '<div class="row">';
 
 			$count_column = 0;
+			$widget_count = 1;
 
-			foreach($layout as $key_l => $w_content):
+			foreach($layout as $w_content):
 				if(!array_key_exists('content', $w_content))
 					continue;
 
 				$layout_widget = str_replace('_widget_acf', '', $w_content['layout']);
 				$widget_name = str_replace('_', '-', $layout_widget);
 				$dir_widget = get_template_directory() . "/widgets-templates/{$widget_name}";
+				$url_widget = get_template_directory_uri() . "/widgets-templates/{$widget_name}";
 				$plugin_widget = false;
 
-				if(function_exists('\App\template') || function_exists('\Roots\view'))
+				if(function_exists('\App\template') || function_exists('\Roots\view')):
 					$dir_widget = get_template_directory() . "/views/widgets-templates/{$widget_name}";
+					$url_widget = get_template_directory_uri() . "/views/widgets-templates/{$widget_name}";
+				endif;
 
 				if(!is_dir($dir_widget)):
 					$dir_widget = plugin_dir_path(__FILE__) . "../more-widgets-templates/{$widget_name}";
@@ -49,14 +53,17 @@ Class TemplatesWidgets {
 				if($count_column > count($w_content['columns']) - 1)
 					$count_column = 0;
 
-				$columns = $w_content['content']['field_tamanho_grid_desktop_' . $layout_widget . '_widget_acf_key'];
-				
+				$columns = $w_content['content']['field_tamanho_grid_desktop_' . $layout_widget . '_widget_acf_key'];				
 				$style = '';
 
 				if($columns == 'full-widget-acf')
-					$style = 'width: 100%; overflow: hidden;';
+					$style = 'style="width: 100%; overflow: hidden;"';
 
-				$html .= "<div class=\"widget_acf {$columns} {$w_content['class']}\" style=\"{$style}\">";
+				$html .= sprintf(
+					"<div id=\"{$widget_name}-{$widget_count}\" class=\"widget-acf {$widget_name} {$columns}%s\"%s>", 
+					empty($w_content['class']) ? "" : " " . $w_content['class'], 
+					empty($style) ? "" : " " . $style
+				);
 
 				ob_start();
 
@@ -78,6 +85,10 @@ Class TemplatesWidgets {
 				$html .= ob_get_clean();
 				$html .= '</div>';
 
+				self::enqueueStyle($dir_widget, $url_widget, $widget_name);
+				self::enqueueScript($dir_widget, $url_widget, $widget_name);
+				
+				$widget_count++;
 				$count_column++;
 			endforeach;
 
@@ -87,6 +98,42 @@ Class TemplatesWidgets {
 		endforeach;
 
 		return $html;
+	}
+
+	/**
+	 * enqueueStyle Adiciona o css do widget em páginas que ele for utilizado
+	 *
+	 * @param  mixed $dir_widget Caminho completo do widget
+	 * @param  mixed $url_widget URL do widget a partir da raiz do Wordpress
+	 * @param  mixed $widget_name Nome do widget
+	 * @return void
+	 */
+	private static function enqueueStyle($dir_widget, $url_widget, $widget_name) {
+		$style = "/style.css";
+
+		if(!file_exists($dir_widget . $style))
+			return;
+
+		// Enqueue style
+		wp_enqueue_style("widget/{$widget_name}", $url_widget . $style, array(), false, 'all');
+	}
+	
+	/**
+	 * enqueueScript Adiciona o script do widget em páginas que ele for utilizado
+	 *
+	 * @param  mixed $dir_widget Caminho completo do widget
+	 * @param  mixed $url_widget URL do widget a partir da raiz do Wordpress
+	 * @param  mixed $widget_name Nome do widget
+	 * @return void
+	 */
+	private static function enqueueScript($dir_widget, $url_widget, $widget_name) {
+		$script = "/script.js";
+
+		if(!file_exists($dir_widget . $script))
+			return;
+
+		// Enqueue script
+		wp_enqueue_script("widget/{$widget_name}", $url_widget . $script, array(), false, true);
 	}
 
 	static function get_image($fields){


### PR DESCRIPTION
Com essa implementação é possível adicionar css e js específicos do widget, basta ter os arquivos `style.css` e `script.js` no mesmo diretório do widget.